### PR TITLE
Add feature toggles for gram backend and cli interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ crate-type = ["rlib"]
 [dependencies]
 pest = "2.0"
 pest_derive = "2.0"
-clap = "2.33.0"
-serde = "1.0"
-serde_yaml = "0.8"
+clap = { version = "2.33.0", optional = true }
+serde = { version = "1.0", optional = true }
+serde_yaml = { version = "0.8", optional = true }
+
+[features]
+default = ["gram", "cli"]
+cli = ["clap"]
+gram = ["serde", "serde_yaml"]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -64,5 +64,5 @@ impl Tokens {
     }
 }
 
-
+#[cfg(feature = "gram")]
 pub(crate) mod gram;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,20 @@ pub struct Database {
 }
 
 impl Database {
+    #[cfg(feature = "gram")]
     pub fn open(path: &str) -> Result<Database, Error> {
         let backend = backend::gram::GramBackend::open(path)?;
         let frontend = Frontend{ tokens: backend.tokens() };
         return Ok(Database {
             backend: Box::new(backend),
+            frontend,
+        })
+    }
+
+    pub fn with_backend(backend: Box<dyn Backend>) -> Result<Database, Error> {
+        let frontend = Frontend{ tokens: backend.tokens() };
+        return Ok(Database {
+            backend,
             frontend,
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,33 @@
-
-extern crate clap;
-
-use gqlite::{Error, Database, Cursor};
-
-use clap::{App, AppSettings};
+use gqlite::Error;
 
 fn main() -> Result<(), Error>{
-    let matches = App::new("g")
-        .version("0.0")
-        .about("A graph database in a gram file!")
-        .setting(AppSettings::ArgRequiredElseHelp)
-        .args_from_usage(
-            "-f, --file=[FILE] @graph.gram 'Sets the gram file to use'
+    #[cfg(all(feature = "cli", feature = "gram"))]
+    {
+        use clap::{App, AppSettings};
+        use gqlite::{Database, Cursor};
+
+        let matches = App::new("g")
+            .version("0.0")
+            .about("A graph database in a gram file!")
+            .setting(AppSettings::ArgRequiredElseHelp)
+            .args_from_usage(
+                "-f, --file=[FILE] @graph.gram 'Sets the gram file to use'
             -h, --help 'Print help information'
             <QUERY> 'Query to execute'")
-        .get_matches();
+            .get_matches();
 
-    let query_str = string_to_static_str(matches.value_of("QUERY").unwrap());
-    let path = matches.value_of("file").unwrap_or("graph.gram");
+        let query_str = string_to_static_str(matches.value_of("QUERY").unwrap());
+        let path = matches.value_of("file").unwrap_or("graph.gram");
 
-    let mut db = Database::open(path)?;
-    let mut cursor = Cursor::new();
-    db.run(query_str, &mut cursor)?;
+        let mut db = Database::open(path)?;
+        let mut cursor = Cursor::new();
+        db.run(query_str, &mut cursor)?;
 
-    while cursor.next()? {
+        while cursor.next()? {
 
+        }
     }
+
     Ok(())
 }
 
@@ -35,6 +37,7 @@ fn main() -> Result<(), Error>{
 //       get rid of that memory sharing entirely, maybe? Although maybe the borrow is actually
 //       kind of sensible; it'd mean queries with large string properties don't need to copy those
 //       strings in, for instance..
+#[cfg(feature = "cli")]
 fn string_to_static_str(s: &str) -> &'static str {
     Box::leak(s.to_string().into_boxed_str())
 }


### PR DESCRIPTION
If I want to pull this in as a library to add my own backend,
I don't necessarily want to pull in the gram backend and the clap
interface to reduce the size of my dependencies.

By default, everything is enabled, nothing should change for the
"cargo run" use-case.

With this I can declare the dependency as
```
gqlite = { path = "../gqlite", default-features = false }
```