### PR TITLE
Remove the need for a 'static query_str

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -23,15 +23,14 @@ pub struct Frontend {
 }
 
 impl Frontend {
-    // TODO obviously the query string shouldn't be static
-    pub fn plan(&self, query_str: &'static str) -> Result<LogicalPlan, Error> {
+    pub fn plan(&self, query_str: &str) -> Result<LogicalPlan, Error> {
         self.plan_in_context(query_str, &mut PlanningContext{
             slots: Default::default(),
             anon_rel_seq:0, anon_node_seq: 0,
             tokens: Rc::clone(&self.tokens)})
     }
 
-    pub fn plan_in_context(&self, query_str: &'static str, mut pc: &mut PlanningContext) -> Result<LogicalPlan, Error> {
+    pub fn plan_in_context<'a>(&self, query_str: &'a str, mut pc: &mut PlanningContext) -> Result<LogicalPlan, Error> {
         let query = CypherParser::parse(Rule::query, query_str)?
             .next().unwrap(); // get and unwrap the `query` rule; never fails
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,7 @@ impl Database {
         })
     }
 
-    // TODO obviously the query string shouldn't be static
-    pub fn run(&mut self, query_str: &'static str, cursor: &mut Cursor) -> Result<(), Error> {
+    pub fn run<'a>(&mut self, query_str: &'a str, cursor: &mut Cursor) -> Result<(), Error> {
         let plan = self.frontend.plan(query_str)?;
 
         println!("plan: {:?}", plan);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Error>{
             <QUERY> 'Query to execute'")
             .get_matches();
 
-        let query_str = string_to_static_str(matches.value_of("QUERY").unwrap());
+        let query_str = matches.value_of("QUERY").unwrap();
         let path = matches.value_of("file").unwrap_or("graph.gram");
 
         let mut db = Database::open(path)?;
@@ -29,15 +29,4 @@ fn main() -> Result<(), Error>{
     }
 
     Ok(())
-}
-
-
-// TODO: The reason for this is that the cursor borrows part of the query string when you
-//       run a query, and rather than deal with setting proper lifetimes for that I think we can
-//       get rid of that memory sharing entirely, maybe? Although maybe the borrow is actually
-//       kind of sensible; it'd mean queries with large string properties don't need to copy those
-//       strings in, for instance..
-#[cfg(feature = "cli")]
-fn string_to_static_str(s: &str) -> &'static str {
-    Box::leak(s.to_string().into_boxed_str())
 }


### PR DESCRIPTION
If you had anything else in mind with the static hack, please let me know.