### PR TITLE
More flexible errors with the anyhow crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +114,7 @@ dependencies = [
 name = "gqlite"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "pest",
  "pest_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ name = "gqlite"
 crate-type = ["rlib"]
 
 [dependencies]
+anyhow = "1.0"
+clap = { version = "2.33.0", optional = true }
 pest = "2.0"
 pest_derive = "2.0"
-clap = { version = "2.33.0", optional = true }
 serde = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8", optional = true }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,15 +2,16 @@
 // Backends implement the actual storage of graphs, and provide implementations of the
 // logical operators the frontend emits that can act on that storage.
 //
-use crate::{Cursor, Error};
+use crate::Cursor;
 use crate::frontend::{LogicalPlan};
+use anyhow::Result;
 use std::fmt::Debug;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 pub trait PreparedStatement: Debug {
-    fn run(&mut self, cursor: &mut Cursor) -> Result<(), Error>;
+    fn run(&mut self, cursor: &mut Cursor) -> Result<()>;
 }
 
 // I don't know if any of this makes any sense, but the thoughts here is like.. lets make it
@@ -23,7 +24,7 @@ pub trait Backend: Debug {
     fn tokens(&self) -> Rc<RefCell<Tokens>>;
 
     // Convert a logical plan into something executable
-    fn prepare(&self, plan: Box<LogicalPlan>) -> Result<Box<dyn PreparedStatement>, Error>;
+    fn prepare(&self, plan: Box<LogicalPlan>) -> Result<Box<dyn PreparedStatement>>;
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate anyhow;
 pub mod backend;
 pub mod frontend;
 
-use anyhow::Result;
+pub use anyhow::{Result, Error};
 use std::fmt::{Display, Formatter, Debug};
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 extern crate pest;
 #[macro_use]
 extern crate pest_derive;
+#[macro_use]
+extern crate anyhow;
 
 pub mod backend;
 pub mod frontend;
 
+use anyhow::Result;
 use std::fmt::{Display, Formatter, Debug};
 use std::fmt;
 
@@ -20,7 +23,7 @@ pub struct Database {
 
 impl Database {
     #[cfg(feature = "gram")]
-    pub fn open(file: &mut File) -> Result<Database, Error> {
+    pub fn open(file: &mut File) -> Result<Database> {
         let backend = backend::gram::GramBackend::open(file)?;
         let frontend = Frontend{ tokens: backend.tokens() };
         return Ok(Database {
@@ -29,7 +32,7 @@ impl Database {
         })
     }
 
-    pub fn with_backend(backend: Box<dyn Backend>) -> Result<Database, Error> {
+    pub fn with_backend(backend: Box<dyn Backend>) -> Result<Database> {
         let frontend = Frontend{ tokens: backend.tokens() };
         return Ok(Database {
             backend,
@@ -38,8 +41,7 @@ impl Database {
     }
 
     // TODO obviously the query string shouldn't be static
-    pub fn run(&mut self, query_str: &str, cursor: &mut Cursor) -> Result<(), Error> {
-        println!("5");
+    pub fn run(&mut self, query_str: &str, cursor: &mut Cursor) -> Result<()> {
         let plan = self.frontend.plan(query_str)?;
         let mut prepped = self.backend.prepare(Box::new(plan))?;
 
@@ -50,7 +52,7 @@ impl Database {
 
 // Backends provide this
 pub trait CursorState : Debug {
-    fn next(&mut self, row:  &mut Row) -> Result<bool, Error>;
+    fn next(&mut self, row:  &mut Row) -> Result<bool>;
 }
 
 // Cursors are like iterators, except they don't require malloc for each row; the row you read is
@@ -68,7 +70,7 @@ impl Cursor {
             row: Row { slots: vec![] }
         }
     }
-    pub fn next(&mut self) -> Result<bool, Error> {
+    pub fn next(&mut self) -> Result<bool> {
         match &mut self.state {
             Some(state) => {
                 return state.next(&mut self.row)
@@ -83,30 +85,6 @@ impl Cursor {
 #[derive(Debug, PartialEq)]
 pub enum Dir {
     Out, In
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Error {
-    // TODO I think maybe this should be &str?
-    pub msg: String,
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        f.write_str(&self.msg)
-    }
-}
-
-impl std::convert::From<std::io::Error> for Error {
-    fn from(e: std::io::Error) -> Self {
-        Error{ msg: format!("from io.error: {:?}", e) }
-    }
-}
-
-impl std::convert::From<pest::error::Error<frontend::Rule>> for Error {
-    fn from(e: pest::error::Error<frontend::Rule>) -> Self {
-        Error{ msg: format!("{}", e)}
-    }
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
-use gqlite::Error;
 use std::fs::File;
 
-fn main() -> Result<(), Error>{
+fn main() -> anyhow::Result<()> {
     #[cfg(all(feature = "cli", feature = "gram"))]
     {
         use clap::{App, AppSettings};


### PR DESCRIPTION
This maintains the same functionality as the custom Error type with less typing and also doesn't require writing `From`s. I found that anyhow is, out of all the various error handling crates, best fitting for ad-hoc errors in a cli tool, but can also easily be used with something like `thiserror` to move to more structured errors later on.