### PR TITLE
Aggregations take 2

### DIFF
--- a/src/backend/gram.rs
+++ b/src/backend/gram.rs
@@ -1,16 +1,16 @@
 // The Gram backend is a backend implementation that acts on a Gram file.
 // It is currently single threaded, and provides no data durability guarantees.
 
-use crate::{Error, Val, Dir, Slot, Row, Cursor, frontend, CursorState, Type};
+use crate::{frontend, Cursor, CursorState, Dir, Error, Row, Slot, Type, Val};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
-use std::cell::RefCell;
 
 use super::PreparedStatement;
+use crate::backend::{BackendDesc, FuncSignature, FuncType, Token, Tokens};
 use crate::frontend::LogicalPlan;
 use anyhow::Result;
 use std::fmt::Debug;
-use crate::backend::{Tokens, Token, FuncSignature, FuncType, BackendDesc};
 use std::fs::File;
 
 #[derive(Debug)]
@@ -64,11 +64,12 @@ impl GramBackend {
                         alias: projection.alias,
                     })
                 }
-                Ok(Box::new(Return{
+                Ok(Box::new(Return {
                     src: self.convert(*src)?,
-                    projections: converted_projections }))
-            },
-            _ => panic!("The gram backend does not yet handle {:?}", plan)
+                    projections: converted_projections,
+                }))
+            }
+            _ => panic!("The gram backend does not yet handle {:?}", plan),
         }
     }
 
@@ -103,11 +104,11 @@ impl super::Backend for GramBackend {
     fn describe(&self) -> Result<BackendDesc, Error> {
         let tok_count = self.tokens.borrow_mut().tokenize("count");
         let tok_expr = self.tokens.borrow_mut().tokenize("expr");
-        Ok(BackendDesc::new(vec![FuncSignature{
+        Ok(BackendDesc::new(vec![FuncSignature {
             func_type: FuncType::Scalar,
             name: tok_count,
             returns: Type::Number,
-            args: vec![(tok_expr, Type::Any)]
+            args: vec![(tok_expr, Type::Any)],
         }]))
     }
 }

--- a/src/backend/gram.rs
+++ b/src/backend/gram.rs
@@ -1,16 +1,17 @@
 // The Gram backend is a backend implementation that acts on a Gram file.
 // It is currently single threaded, and provides no data durability guarantees.
 
-use super::PreparedStatement;
-use crate::backend::{Token, Tokens};
-use crate::frontend::LogicalPlan;
-use crate::{frontend, Cursor, CursorState, Dir, Row, Slot, Val};
-use anyhow::Result;
-use std::cell::RefCell;
+use crate::{Error, Val, Dir, Slot, Row, Cursor, frontend, CursorState, Type};
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
-use std::fs::File;
 use std::rc::Rc;
+use std::cell::RefCell;
+
+use super::PreparedStatement;
+use crate::frontend::LogicalPlan;
+use anyhow::Result;
+use std::fmt::Debug;
+use crate::backend::{Tokens, Token, FuncSignature, FuncType, BackendDesc};
+use std::fs::File;
 
 #[derive(Debug)]
 pub struct GramBackend {
@@ -55,9 +56,6 @@ impl GramBackend {
                 next_rel_index: 0,
                 state: ExpandState::NextNode,
             })),
-            LogicalPlan::Create { .. } => {
-                panic!("The gram backend does not yet support CREATE statements")
-            }
             LogicalPlan::Return { src, projections } => {
                 let mut converted_projections = Vec::new();
                 for projection in projections {
@@ -66,12 +64,11 @@ impl GramBackend {
                         alias: projection.alias,
                     })
                 }
-
-                Ok(Box::new(Return {
+                Ok(Box::new(Return{
                     src: self.convert(*src)?,
-                    projections: converted_projections,
-                }))
-            }
+                    projections: converted_projections }))
+            },
+            _ => panic!("The gram backend does not yet handle {:?}", plan)
         }
     }
 
@@ -101,6 +98,17 @@ impl super::Backend for GramBackend {
             // TODO: pipe this knowledge through from logial plan
             num_slots: 16,
         }))
+    }
+
+    fn describe(&self) -> Result<BackendDesc, Error> {
+        let tok_count = self.tokens.borrow_mut().tokenize("count");
+        let tok_expr = self.tokens.borrow_mut().tokenize("expr");
+        Ok(BackendDesc::new(vec![FuncSignature{
+            func_type: FuncType::Scalar,
+            name: tok_count,
+            returns: Type::Number,
+            args: vec![(tok_expr, Type::Any)]
+        }]))
     }
 }
 
@@ -320,7 +328,7 @@ impl Operator for Argument {
 #[derive(Debug, Clone)]
 struct Projection {
     pub expr: Expr,
-    pub alias: String,
+    pub alias: Token,
 }
 
 #[derive(Debug)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,13 +2,13 @@
 // Backends implement the actual storage of graphs, and provide implementations of the
 // logical operators the frontend emits that can act on that storage.
 //
+use crate::frontend::LogicalPlan;
 use crate::{Cursor, Error, Type};
-use crate::frontend::{LogicalPlan};
 use anyhow::Result;
-use std::fmt::Debug;
-use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::rc::Rc;
 
 pub trait PreparedStatement: Debug {
     fn run(&mut self, cursor: &mut Cursor) -> Result<()>;
@@ -49,7 +49,10 @@ impl BackendDesc {
                 aggregates.insert(f.name);
             }
         }
-        return BackendDesc{ functions, aggregates }
+        return BackendDesc {
+            functions,
+            aggregates,
+        };
     }
 }
 
@@ -79,7 +82,7 @@ pub enum FuncType {
     //
     //   MATCH (n) RETURN n.age, count(n)
     //
-    Aggregating
+    Aggregating,
 }
 
 // See the "functions" section in the openCypher spec https://s3.amazonaws.com/artifacts.opencypher.org/openCypher9.pdf

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,13 +2,13 @@
 // Backends implement the actual storage of graphs, and provide implementations of the
 // logical operators the frontend emits that can act on that storage.
 //
-use crate::frontend::LogicalPlan;
-use crate::Cursor;
+use crate::{Cursor, Error, Type};
+use crate::frontend::{LogicalPlan};
 use anyhow::Result;
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::rc::Rc;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 
 pub trait PreparedStatement: Debug {
     fn run(&mut self, cursor: &mut Cursor) -> Result<()>;
@@ -24,7 +24,75 @@ pub trait Backend: Debug {
     fn tokens(&self) -> Rc<RefCell<Tokens>>;
 
     // Convert a logical plan into something executable
-    fn prepare(&self, plan: Box<LogicalPlan>) -> Result<Box<dyn PreparedStatement>>;
+    fn prepare(&self, plan: Box<LogicalPlan>) -> Result<Box<dyn PreparedStatement>, Error>;
+
+    // Describe this backend for the frontends benefit
+    fn describe(&self) -> Result<BackendDesc, Error>;
+}
+
+// Describes, for the frontend, the layout of the backend. This is intended to include things
+// like schema (which the planner can take advantage of to perform optimizations), but also
+// type signatures of functions and perhaps listings of available special features for the planner
+// to use.
+#[derive(Debug)]
+pub struct BackendDesc {
+    pub functions: Vec<FuncSignature>,
+    // Fast lookup of functions that aggregate
+    pub aggregates: HashSet<Token>,
+}
+
+impl BackendDesc {
+    pub fn new(functions: Vec<FuncSignature>) -> BackendDesc {
+        let mut aggregates = HashSet::new();
+        for f in &functions {
+            if let FuncType::Aggregating = f.func_type {
+                aggregates.insert(f.name);
+            }
+        }
+        return BackendDesc{ functions, aggregates }
+    }
+}
+
+#[derive(Debug)]
+pub enum FuncType {
+    // If you imagine cypher as a stream processing system, each operator consumes one or more
+    // input streams and yields an output stream. In expressions with scalar functions, each
+    // input row maps to one output row.
+    //
+    // For example, the following query involves a scalar function:
+    //
+    //   MATCH (n) RETURN id(n)
+    //
+    // The MATCH (n) part yields a stream of every node in the graph, and the RETURN id(n) part
+    // operates on one row at a time, yielding an output row with the node id for each input row.
+    Scalar,
+    // Aggregating functions change the operator cardinality - an operator with aggregating functions
+    // may yield output rows than it consumed. For instance, this query:
+    //
+    //   MATCH (n) RETURN count(n)
+    //
+    // Here, the "MATCH (n)" part yields a stream of every node in the graph. The "RETURN count(n)"
+    // part consumes that stream, and yields exactly one row with the count. The "count" function
+    // is aggregating rows.
+    //
+    // There are examples of aggregations yielding more than one row, when grouping is involved:
+    //
+    //   MATCH (n) RETURN n.age, count(n)
+    //
+    Aggregating
+}
+
+// See the "functions" section in the openCypher spec https://s3.amazonaws.com/artifacts.opencypher.org/openCypher9.pdf
+#[derive(Debug)]
+pub struct FuncSignature {
+    // Aggregate or scalar?
+    pub func_type: FuncType,
+    // Name of this function
+    pub name: Token,
+    // Return type
+    pub returns: Type,
+    // Named arguments
+    pub args: Vec<(Token, Type)>,
 }
 
 // gql databases are filled with short string keys. Both things stored in the graph, like property

--- a/src/cypher.pest
+++ b/src/cypher.pest
@@ -1,11 +1,13 @@
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
 
-expr = { string | prop_lookup | id }
+expr = { prop_lookup | func_call | string | id }
 
 id = ${ ( ASCII_ALPHA | "_" | "-" ) + }
 
 prop_lookup = { id ~ ("." ~ id)+ }
+
+func_call = { id ~ "(" ~ (expr ~ ("," ~ expr)*)? ~ ")" }
 
 string = ${ "\"" ~ str_inner ~ "\"" }
 str_inner = @{ char* }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,17 +25,15 @@ impl Database {
     #[cfg(feature = "gram")]
     pub fn open(file: &mut File) -> Result<Database> {
         let backend = backend::gram::GramBackend::open(file)?;
-        return Database::with_backend(Box::new(backend))
+        return Database::with_backend(Box::new(backend));
     }
 
     pub fn with_backend(backend: Box<dyn Backend>) -> Result<Database, Error> {
-        let frontend = Frontend{
+        let frontend = Frontend {
             tokens: backend.tokens(),
-            backend_desc: backend.describe()? };
-        return Ok(Database {
-            backend,
-            frontend,
-        })
+            backend_desc: backend.describe()?,
+        };
+        return Ok(Database { backend, frontend });
     }
 
     pub fn run(&mut self, query_str: &str, cursor: &mut Cursor) -> Result<(), Error> {
@@ -114,7 +112,7 @@ pub enum Type {
     Map,
 }
 
-#[derive(Debug,Clone,PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Val {
     Null,
     String(String),


### PR DESCRIPTION
This allows backends to declare functions they support (and lays some API foundations for more things backends can say about themselves, like indexes..), and the frontend will then plan aggregations if queries contain expressions that call aggregating functions. 