### PR TITLE
rename gqlite binary (cli) 'g'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ members = [
 name = "gqlite"
 crate-type = ["rlib"]
 
+[[bin]]
+name = "g"
+path = "src/main.rs"
+doc = false
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "2.33.0", optional = true }


### PR DESCRIPTION
This changes cli from:
`gqlite -f miserables.gram "MATCH (n:Person) RETURN n.name, n.group"`
to
`g -f miserables.gram "MATCH (n:Person) RETURN n.name, n.group"`
but perhaps we don't want to do that anymore