### PR TITLE
Add more info to Expand/Match and address warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,18 @@ doc = false
 [dependencies]
 anyhow = "1.0"
 clap = { version = "2.33.0", optional = true }
+json = { version = "0.12", optional = true }
 pest = "2.0"
 pest_derive = "2.0"
-rand = "0.7"
+rand = { version = "0.7", optional = true }
 serde = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8", optional = true }
-uuid = { version = "0.8", features = ["v1"] }
-json = "0.12"
+uuid = { version = "0.8", features = ["v1"], optional = true }
 
 [features]
 default = ["gram", "cli"]
 cli = ["clap"]
-gram = ["serde", "serde_yaml"]
+gram = ["json", "rand", "serde", "serde_yaml", "uuid"]
 
 [dev-dependencies]
 cucumber = { package = "cucumber_rust", version = "^0.6.0" }
@@ -42,4 +42,5 @@ tempfile = "3.1.0"
 
 [[test]]
 name = "cucumber"
+required-features = ["gram"]
 harness = false # Allows Cucumber to print output instead of libtest

--- a/gqlite-capi/src/lib.rs
+++ b/gqlite-capi/src/lib.rs
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn gqlite_open(raw_url: *const c_char) -> *const database 
     let url: &str = str::from_utf8(url_bytes).unwrap();
 
     match File::open(url) {
-        Ok(mut file) => Box::into_raw(Box::new(database {
+        Ok(file) => Box::into_raw(Box::new(database {
             db: Some(Database::open(file).unwrap()),
             last_error: None,
         })),

--- a/src/backend/gram.rs
+++ b/src/backend/gram.rs
@@ -77,6 +77,7 @@ impl GramBackend {
                 rel_slot,
                 dst_slot,
                 rel_type,
+                ..
             } => Ok(Rc::new(RefCell::new(Expand {
                 src: self.convert(src)?,
                 src_slot,

--- a/src/backend/gram.rs
+++ b/src/backend/gram.rs
@@ -87,6 +87,8 @@ impl GramBackend {
                 next_rel_index: 0,
                 state: ExpandState::NextNode,
             }))),
+            // TODO: unwrap selection for now, actually implement
+            LogicalPlan::Selection { src, .. } => self.convert(src),
             LogicalPlan::Return { src, projections } => {
                 let mut converted_projections = Vec::new();
                 for projection in projections {

--- a/src/backend/gram.rs
+++ b/src/backend/gram.rs
@@ -83,7 +83,7 @@ impl GramBackend {
                 src_slot,
                 rel_slot,
                 dst_slot,
-                rel_type,
+                rel_type: rel_type.token(),
                 next_rel_index: 0,
                 state: ExpandState::NextNode,
             }))),

--- a/src/backend/gram.rs
+++ b/src/backend/gram.rs
@@ -31,11 +31,11 @@ impl GramBackend {
         };
         let g = parser::load(&mut tokens, &mut file)?;
 
-        return Ok(GramBackend {
+        Ok(GramBackend {
             tokens: Rc::new(RefCell::new(tokens)),
             g: Rc::new(RefCell::new(g)),
             file: Rc::new(RefCell::new(file)),
-        });
+        })
     }
 
     fn convert(&self, plan: Box<LogicalPlan>) -> Result<Rc<RefCell<dyn Operator>>, Error> {
@@ -49,8 +49,7 @@ impl GramBackend {
             }))),
             LogicalPlan::Create { src, nodes, .. } => {
                 let mut out_nodes = Vec::with_capacity(nodes.len());
-                let mut i = 0;
-                for ns in nodes {
+                for (i, ns) in nodes.into_iter().enumerate() {
                     let mut props = HashMap::new();
                     for k in ns.props {
                         props.insert(k.key, self.convert_expr(k.val));
@@ -60,10 +59,9 @@ impl GramBackend {
                         NodeSpec {
                             slot: ns.slot,
                             labels: ns.labels.iter().copied().collect(),
-                            props: props,
+                            props,
                         },
                     );
-                    i += 1;
                 }
                 Ok(Rc::new(RefCell::new(Create {
                     src: self.convert(src)?,
@@ -128,13 +126,13 @@ impl super::Backend for GramBackend {
 
     fn prepare(&self, logical_plan: Box<LogicalPlan>) -> Result<Box<dyn PreparedStatement>> {
         let plan = self.convert(logical_plan)?;
-        return Ok(Box::new(Statement {
+        Ok(Box::new(Statement {
             file: Rc::clone(&self.file),
             g: Rc::clone(&self.g),
             plan,
-            // TODO: pipe this knowledge through from logial plan
+            // TODO: pipe this knowledge through from logical plan
             num_slots: 16,
-        }));
+        }))
     }
 
     fn describe(&self) -> Result<BackendDesc, Error> {
@@ -169,7 +167,7 @@ impl PreparedStatement for Statement {
         if cursor.row.slots.len() < self.num_slots {
             cursor.row.slots.resize(self.num_slots, Val::Null);
         }
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -583,11 +581,11 @@ struct NodeSpec {
 
 impl Clone for NodeSpec {
     fn clone(&self) -> Self {
-        return NodeSpec {
+        NodeSpec {
             slot: self.slot,
             labels: self.labels.iter().cloned().collect(),
             props: self.props.clone(),
-        };
+        }
     }
 
     fn clone_from(&mut self, _source: &'_ Self) {
@@ -649,7 +647,7 @@ fn generate_uuid() -> Uuid {
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
     let ts = Timestamp::from_unix(&context, now.as_secs(), now.subsec_nanos());
-    return Uuid::new_v1(ts, &node_id).expect("failed to generate UUID");
+    Uuid::new_v1(ts, &node_id).expect("failed to generate UUID")
 }
 
 fn append_node(
@@ -664,26 +662,25 @@ fn append_node(
         .map(|kvp| (tokens.lookup(*kvp.0).unwrap(), (*kvp.1).as_string_literal()))
         .collect();
     let gram_identifier = generate_uuid().to_hyphenated().to_string();
-    let gram_string: String;
-    if !labels.is_empty() {
+    let gram_string = if !labels.is_empty() {
         let labels_gram_ready: Vec<&str> =
             labels.iter().map(|l| tokens.lookup(*l).unwrap()).collect();
-        gram_string = format!(
+        format!(
             "(`{}`:{} {})\n",
             gram_identifier,
             labels_gram_ready.join(":"),
             json::stringify(properties_gram_ready)
-        );
+        )
     } else {
-        gram_string = format!(
+        format!(
             "(`{}` {})\n",
             gram_identifier,
             json::stringify(properties_gram_ready)
-        );
-    }
+        )
+    };
 
     let out_node = Node {
-        labels: labels,
+        labels,
         properties: node_properties,
         rels: vec![],
     };
@@ -701,8 +698,8 @@ fn append_node(
         .seek(SeekFrom::End(0))
         .expect("seek error");
 
-    return match ctx.file.borrow_mut().write_all(gram_string.as_bytes()) {
+    match ctx.file.borrow_mut().write_all(gram_string.as_bytes()) {
         Ok(_) => Ok(Val::Node(node_id)),
         Err(e) => Err(Error::new(e)),
-    };
+    }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -49,10 +49,10 @@ impl BackendDesc {
                 aggregates.insert(f.name);
             }
         }
-        return BackendDesc {
+        BackendDesc {
             functions,
             aggregates,
-        };
+        }
     }
 }
 

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -92,6 +92,7 @@ pub enum LogicalPlan {
         rel_slot: usize,
         dst_slot: usize,
         rel_type: Token,
+        dir: Option<Dir>,
     },
     Create {
         src: Box<Self>,
@@ -504,6 +505,7 @@ fn plan_match<'i, 'pc>(
                     rel_slot: pc.get_or_alloc_slot(rel.identifier),
                     dst_slot: pc.get_or_alloc_slot(right_id),
                     rel_type: rel.rel_type,
+                    dir: rel.dir,
                 };
             } else if !left_solved && right_solved {
                 // Right is solved and left isn't, so we can expand to the left
@@ -517,6 +519,7 @@ fn plan_match<'i, 'pc>(
                     rel_slot: pc.get_or_alloc_slot(rel.identifier),
                     dst_slot: pc.get_or_alloc_slot(left_id),
                     rel_type: rel.rel_type,
+                    dir: rel.dir.map(Dir::reverse),
                 };
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ impl Database {
     #[cfg(feature = "gram")]
     pub fn open(file: File) -> Result<Database> {
         let backend = backend::gram::GramBackend::open(file)?;
-        return Database::with_backend(Box::new(backend));
+        Database::with_backend(Box::new(backend))
     }
 
     pub fn with_backend(backend: Box<dyn Backend>) -> Result<Database, Error> {
@@ -34,7 +34,7 @@ impl Database {
             tokens: backend.tokens(),
             backend_desc: backend.describe()?,
         };
-        return Ok(Database { backend, frontend });
+        Ok(Database { backend, frontend })
     }
 
     pub fn run(&mut self, query_str: &str, cursor: &mut Cursor) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ extern crate pest;
 extern crate pest_derive;
 #[macro_use]
 extern crate anyhow;
-extern crate rand;
 
 pub mod backend;
 pub mod frontend;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,18 @@ impl Cursor {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Dir {
     Out,
     In,
+}
+impl Dir {
+    fn reverse(self) -> Self {
+        match self {
+            Dir::Out => Dir::In,
+            Dir::In => Dir::Out,
+        }
+    }
 }
 
 #[derive(Debug, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
-use std::fs::OpenOptions;
-
 fn main() -> anyhow::Result<()> {
     #[cfg(all(feature = "cli", feature = "gram"))]
     {
         use clap::{App, AppSettings};
         use gqlite::{Cursor, Database};
+        use std::fs::OpenOptions;
 
         let matches = App::new("g")
             .version("0.0")
@@ -17,7 +16,7 @@ fn main() -> anyhow::Result<()> {
             )
             .get_matches();
 
-        let query_str = string_to_static_str(matches.value_of("QUERY").unwrap());
+        let query_str = matches.value_of("QUERY").unwrap();
         let path = matches.value_of("file").unwrap_or("graph.gram");
         let file = OpenOptions::new()
             .create(false)
@@ -32,14 +31,4 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-// TODO: The reason for this is that the cursor borrows part of the query string when you
-//       run a query, and rather than deal with setting proper lifetimes for that I think we can
-//       get rid of that memory sharing entirely, maybe? Although maybe the borrow is actually
-//       kind of sensible; it'd mean queries with large string properties don't need to copy those
-//       strings in, for instance..
-#[cfg(feature = "cli")]
-fn string_to_static_str(s: &str) -> &'static str {
-    Box::leak(s.to_string().into_boxed_str())
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,10 +1,10 @@
-use cucumber::{after, before, cucumber, steps, Step};
+use cucumber::{after, before, cucumber};
 use gqlite::{Cursor, Database};
 use tempfile::tempfile;
 
 pub struct GraphProperties {
     node_count: i32,
-    relationship_count: i32,
+    _relationship_count: i32,
 }
 
 fn empty_db() -> Database {
@@ -28,7 +28,7 @@ impl std::default::Default for MyWorld {
             result: Cursor::new(),
             starting_graph_properties: GraphProperties {
                 node_count: 0,
-                relationship_count: 0,
+                _relationship_count: 0,
             },
         }
     }
@@ -37,7 +37,7 @@ impl std::default::Default for MyWorld {
 mod example_steps {
     use super::{empty_db, MyWorld};
     use cucumber::{steps, Step};
-    use gqlite::{Cursor, Database, Error};
+    use gqlite::{Cursor, Error};
 
     fn run_preparatory_query(world: &mut MyWorld, step: &Step) -> Result<(), Error> {
         let mut cursor = Cursor::new();
@@ -84,16 +84,16 @@ mod example_steps {
 
     // Any type that implements cucumber::World + Default can be the world
     steps!(crate::MyWorld => {
-        given "any graph" |world, step| {
+        given "any graph" |_world, _step| {
             // Don't need to do anything
         };
 
-        given "an empty graph" |world, step| {
+        given "an empty graph" |world, _step| {
             world.graph = empty_db();
         };
 
         given "having executed:" |world, step| {
-            run_preparatory_query(world, step);
+            run_preparatory_query(world, step).unwrap();
         };
 
         when "executing query:" |world, step| {
@@ -101,7 +101,7 @@ mod example_steps {
             start_query(world, step)
         };
 
-        then "the result should be empty" |world, step| {
+        then "the result should be empty" |world, _step| {
             // Check that the outcomes to be observed have occurred
             assert_eq!(0, count_rows(&mut world.result).unwrap());
         };
@@ -115,12 +115,12 @@ mod example_steps {
 }
 
 // Declares a before handler function named `a_before_fn`
-before!(a_before_fn => |scenario| {
+before!(a_before_fn => |_scenario| {
 
 });
 
 // Declares an after handler function named `an_after_fn`
-after!(an_after_fn => |scenario| {
+after!(an_after_fn => |_scenario| {
 
 });
 

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -45,7 +45,7 @@ mod example_steps {
         while cursor.next()? {
             // consume
         }
-        return result;
+        result
     }
 
     fn start_query(world: &mut MyWorld, step: &Step) {
@@ -60,7 +60,7 @@ mod example_steps {
         while result.next()? {
             ct += 1
         }
-        return Ok(ct);
+        Ok(ct)
     }
 
     fn count_nodes(world: &mut MyWorld) -> i32 {
@@ -69,7 +69,7 @@ mod example_steps {
             .graph
             .run("MATCH (n) RETURN n", &mut cursor)
             .expect("should succeed");
-        return count_rows(&mut cursor).unwrap();
+        count_rows(&mut cursor).unwrap()
     }
 
     fn assert_side_effect(world: &mut MyWorld, kind: &str, val: &str) {


### PR DESCRIPTION
- Add better type and direction info to Expand
- Add possible selection after expand, otherwise `MATCH (n:Person)-->(o:Person)` could match anything on `o`, not just Persons
- Address warnings
- Move gram backend dependencies behind gram feature gate