### PR TITLE
Reduce amount of pointer indirections

### DIFF
--- a/gqlite-capi/src/lib.rs
+++ b/gqlite-capi/src/lib.rs
@@ -1,7 +1,7 @@
 // If the documentation is available, we should warn on this (remove the next line and this comment)
 #![allow(clippy::missing_safety_doc)]
 
-use gqlite::{Cursor, Database, Error};
+use gqlite::{Cursor, Database, Error, GramCursor, GramDatabase};
 use std::ffi::CStr;
 use std::fs::File;
 use std::os::raw::{c_char, c_int};
@@ -10,14 +10,14 @@ use std::str;
 #[repr(C)]
 #[derive(Debug)]
 pub struct database {
-    pub db: Option<Database>,
+    pub db: Option<GramDatabase>,
     pub last_error: Option<Error>,
 }
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct cursor {
-    cursor: Cursor,
+    cursor: GramCursor,
 }
 
 // Open a database file

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -28,7 +28,7 @@ pub trait Backend: Debug {
     fn tokens(&self) -> Rc<RefCell<Tokens>>;
 
     // Convert a logical plan into something executable
-    fn prepare(&self, plan: Box<LogicalPlan>) -> Result<Self::Statement, Error>;
+    fn prepare(&self, plan: LogicalPlan) -> Result<Self::Statement, Error>;
 
     // Describe this backend for the frontends benefit
     fn describe(&self) -> Result<BackendDesc, Error>;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,7 +3,7 @@
 // logical operators the frontend emits that can act on that storage.
 //
 use crate::frontend::LogicalPlan;
-use crate::{Cursor, Error, Type};
+use crate::{Cursor, CursorState, Error, Type};
 use anyhow::Result;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -11,7 +11,9 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 pub trait PreparedStatement: Debug {
-    fn run(&mut self, cursor: &mut Cursor) -> Result<()>;
+    type State: CursorState;
+
+    fn run(self, cursor: &mut Cursor<Self::State>) -> Result<()>;
 }
 
 // I don't know if any of this makes any sense, but the thoughts here is like.. lets make it
@@ -21,10 +23,12 @@ pub trait PreparedStatement: Debug {
 // in the planning side and in the API to not have to deal with different backends having different
 // generics. Much of that difficulty is likely my poor Rust skills tho.
 pub trait Backend: Debug {
+    type Statement: PreparedStatement;
+
     fn tokens(&self) -> Rc<RefCell<Tokens>>;
 
     // Convert a logical plan into something executable
-    fn prepare(&self, plan: Box<LogicalPlan>) -> Result<Box<dyn PreparedStatement>, Error>;
+    fn prepare(&self, plan: Box<LogicalPlan>) -> Result<Self::Statement, Error>;
 
     // Describe this backend for the frontends benefit
     fn describe(&self) -> Result<BackendDesc, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ impl<T: Backend> Database<T> {
         cursor: &mut Cursor<BackendState<T>>,
     ) -> Result<(), Error> {
         let plan = self.frontend.plan(query_str)?;
-        let prepped = self.backend.prepare(Box::new(plan))?;
+        let prepped = self.backend.prepare(plan)?;
 
         // The API then allows us to modify this to reuse existing CursorState if we like
         PreparedStatement::run(prepped, cursor)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,23 +13,19 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::fs::File;
 
 use crate::frontend::Frontend;
-use backend::Backend;
+use backend::{Backend, PreparedStatement};
 use std::cmp::Ordering;
 
 #[derive(Debug)]
-pub struct Database {
-    backend: Box<dyn Backend>,
+pub struct Database<T: Backend> {
+    backend: T,
     frontend: Frontend,
 }
 
-impl Database {
-    #[cfg(feature = "gram")]
-    pub fn open(file: File) -> Result<Database> {
-        let backend = backend::gram::GramBackend::open(file)?;
-        Database::with_backend(Box::new(backend))
-    }
+type BackendState<T> = <<T as Backend>::Statement as PreparedStatement>::State;
 
-    pub fn with_backend(backend: Box<dyn Backend>) -> Result<Database, Error> {
+impl<T: Backend> Database<T> {
+    pub fn with_backend(backend: T) -> Result<Database<T>> {
         let frontend = Frontend {
             tokens: backend.tokens(),
             backend_desc: backend.describe()?,
@@ -37,12 +33,30 @@ impl Database {
         Ok(Database { backend, frontend })
     }
 
-    pub fn run(&mut self, query_str: &str, cursor: &mut Cursor) -> Result<(), Error> {
+    pub fn run(
+        &mut self,
+        query_str: &str,
+        cursor: &mut Cursor<BackendState<T>>,
+    ) -> Result<(), Error> {
         let plan = self.frontend.plan(query_str)?;
-        let mut prepped = self.backend.prepare(Box::new(plan))?;
+        let prepped = self.backend.prepare(Box::new(plan))?;
 
         // The API then allows us to modify this to reuse existing CursorState if we like
-        prepped.run(cursor)
+        PreparedStatement::run(prepped, cursor)
+    }
+}
+
+#[cfg(feature = "gram")]
+pub type GramDatabase = Database<backend::gram::GramBackend>;
+
+#[cfg(feature = "gram")]
+pub type GramCursor = Cursor<backend::gram::GramCursorState>;
+
+#[cfg(feature = "gram")]
+impl Database<backend::gram::GramBackend> {
+    pub fn open(file: File) -> Result<Database<backend::gram::GramBackend>> {
+        let backend = backend::gram::GramBackend::open(file)?;
+        Database::with_backend(backend)
     }
 }
 
@@ -63,15 +77,18 @@ pub trait CursorState: Debug {
 
 // Cursors are like iterators, except they don't require malloc for each row; the row you read is
 // valid until next time you call "next", or until the transaction you are in is closed.
-#[derive(Debug, Default)]
-pub struct Cursor {
-    pub state: Option<Box<dyn CursorState>>,
+#[derive(Debug)]
+pub struct Cursor<S: CursorState> {
+    pub state: Option<S>,
     pub row: Row,
 }
 
-impl Cursor {
-    pub fn new() -> Cursor {
-        Cursor::default()
+impl<S: CursorState> Cursor<S> {
+    pub fn new() -> Cursor<S> {
+        Cursor {
+            state: None,
+            row: Row::default(),
+        }
     }
 
     #[allow(clippy::should_implement_trait)]
@@ -198,7 +215,7 @@ impl PartialOrd for Val {
                 Val::String(_) => Some(Ordering::Less),
                 Val::Int(_) => Some(Ordering::Less),
                 Val::Float(_) => Some(Ordering::Less),
-                Val::List(other_v) => self_v.partial_cmp(other_v),
+                Val::List(other_v) => self_v.partial_cmp(&other_v),
                 Val::Null => None,
                 _ => panic!("Don't know how to compare {:?} to {:?}", self, other),
             },

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,5 +1,5 @@
 use cucumber::{after, before, cucumber};
-use gqlite::{Cursor, Database};
+use gqlite::{Cursor, Database, GramCursor, GramDatabase};
 use tempfile::tempfile;
 
 pub struct GraphProperties {
@@ -7,15 +7,15 @@ pub struct GraphProperties {
     _relationship_count: i32,
 }
 
-fn empty_db() -> Database {
+fn empty_db() -> GramDatabase {
     Database::open(tempfile().unwrap()).unwrap()
 }
 
 pub struct MyWorld {
     // You can use this struct for mutable context in scenarios.
-    graph: Database,
+    graph: GramDatabase,
     starting_graph_properties: GraphProperties,
-    result: Cursor,
+    result: GramCursor,
 }
 
 impl cucumber::World for MyWorld {}
@@ -37,7 +37,7 @@ impl std::default::Default for MyWorld {
 mod example_steps {
     use super::{empty_db, MyWorld};
     use cucumber::{steps, Step};
-    use gqlite::{Cursor, Error, Val};
+    use gqlite::{Cursor, Error, GramCursor, Val};
     use std::iter::Peekable;
     use std::str::Chars;
 
@@ -57,7 +57,7 @@ mod example_steps {
             .expect("Should not fail")
     }
 
-    fn count_rows(result: &mut Cursor) -> Result<i32, Error> {
+    fn count_rows(result: &mut GramCursor) -> Result<i32, Error> {
         let mut ct = 0;
         while result.next()? {
             ct += 1


### PR DESCRIPTION
The PreparedStatement now consumes itself on calling run, i.e. it can only be run once.
This allows us to move the plan into the cursor and not have to keep a `Rc` copy of it.
We can now put the plan behind simple `Box`es, the `Rc<RefCell<_>>` is no longer needed.

Using associated types on Backend/Statement and a declared type parameter on the Cursor
allows us to remove some more trait object usages. It is really only the signature for
`Database::run` that had to suffer a bit, but it can be managed with the help if some
type aliases.