### PR TITLE
fixes #31 create files if they don't exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> anyhow::Result<()> {
         let query_str = matches.value_of("QUERY").unwrap();
         let path = matches.value_of("file").unwrap_or("graph.gram");
         let file = OpenOptions::new()
-            .create(false)
+            .create(true)
             .write(true)
             .read(true)
             .open(path)?;


### PR DESCRIPTION
I thought it was going to take more than this but it ended up being embarrassingly easy.

Demo:

```
user@strongbad gqlite (issue-31-file-existence) $ ./target/debug/g -f IDoNotExist.db 'CREATE (p:Foo { x: "Hello" })'
plan: Create { src: Argument, nodes: [NodeSpec { slot: 0, labels: [4], props: [MapEntryExpr { key: 5, val: Lit(String("Hello")) }] }], rels: [] }
--- About to write ---
(`dbe66cda-5d7a-11ea-802a-c112443ebfed`:Foo {"x":"Hello"})

------
user@strongbad gqlite (issue-31-file-existence) $ cat IDoNotExist.db 
(`dbe66cda-5d7a-11ea-802a-c112443ebfed`:Foo {"x":"Hello"})
```