### PR TITLE
Add basic planner support for WHERE

### DIFF
--- a/src/cypher.pest
+++ b/src/cypher.pest
@@ -1,7 +1,14 @@
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
 
-expr = { float | int | prop_lookup | func_call | string | id | list }
+expr = { and_expr ~ (^"OR" ~ and_expr)* }
+and_expr = { term ~ (^"AND" ~ term)* }
+term = _{ binary_op | atom }
+
+binary_op = { atom ~ op ~ atom }
+op = { "=" }
+
+atom = _{ bool | float | int | prop_lookup | func_call | string | id | list | "(" ~ expr ~ ")" }
 
 id = ${ ( ASCII_ALPHA | "_" | "-" ) + }
 
@@ -22,6 +29,10 @@ singleq_char = {
     !("'" | "\\") ~ ANY
     | "\\" ~ ("'" | "\\" | "/" | "b" | "f" | "n" | "r" | "t")
 }
+
+bool = _{ lit_true | lit_false }
+lit_true = { ^"TRUE" }
+lit_false = { ^"FALSE" }
 
 int = {
     "-"? ~ ( "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* )
@@ -56,8 +67,10 @@ pattern = { node  ~ ( rel ~ node )* }
 projection = { expr ~ ("AS" ~ id)? }
 projections = { projection ~ ( "," ~ projection )* }
 
+where_clause = { "WHERE" ~ expr }
+
 create_stmt = { "CREATE" ~ pattern }
-match_stmt = { "MATCH" ~ pattern }
+match_stmt = { "MATCH" ~ pattern ~ where_clause? }
 unwind_stmt = { "UNWIND" ~ expr ~ "AS" ~ id }
 return_stmt = { "RETURN" ~ projections }
 

--- a/src/frontend/expr.rs
+++ b/src/frontend/expr.rs
@@ -112,9 +112,9 @@ pub(super) fn plan_expr(pc: &mut PlanningContext, expression: Pair<Rule>) -> Res
         }
     }
     if or_expressions.len() == 1 {
-        return Ok(or_expressions.remove(0));
+        Ok(or_expressions.remove(0))
     } else {
-        return Ok(Expr::Or(or_expressions));
+        Ok(Expr::Or(or_expressions))
     }
 }
 

--- a/src/frontend/expr.rs
+++ b/src/frontend/expr.rs
@@ -7,9 +7,40 @@ use crate::{Slot, Val};
 use pest::iterators::Pair;
 use std::collections::HashSet;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
+pub enum Op {
+    Eq,
+}
+
+impl Op {
+    pub fn from_str(s: &str) -> Result<Op> {
+        match s {
+            "=" => Ok(Op::Eq),
+            _ => Err(anyhow!("Unknown operator: {}", s)),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
 pub enum Expr {
+    And(Vec<Self>),
+    Or(Vec<Self>),
+
+    // An operator that takes two expressions as its arguments, for instance
+    // "a = b" or "a > b".
+    BinaryOp {
+        left: Box<Self>,
+        right: Box<Self>,
+        op: Op,
+    },
+
+    Bool(bool),
+
+    // TODO: Drop this in favor of having the literal types directly at this level, so we can
+    //       remove the dependency on Val, so that backends can be free to define Val representations
+    //       as they prefer
     Lit(Val),
+
     // Lookup a property by id
     Prop(Box<Self>, Vec<Token>),
     Slot(Slot),
@@ -18,7 +49,13 @@ pub enum Expr {
     Map(Vec<MapEntryExpr>),
     // Same as map expressions in that they differ from List(Val::List) in having nested exprs
     List(Vec<Expr>),
-    FuncCall { name: Token, args: Vec<Expr> },
+    FuncCall {
+        name: Token,
+        args: Vec<Expr>,
+    },
+
+    // True if the Node in the specified Slot has the specified Label
+    HasLabel(Slot, Token),
 }
 
 impl Expr {
@@ -36,80 +73,264 @@ impl Expr {
                 aggregating_funcs.contains(name)
                     || args.iter().any(|c| c.is_aggregating(aggregating_funcs))
             }
+            Expr::And(terms) => terms.iter().any(|c| c.is_aggregating(aggregating_funcs)),
+            Expr::Or(terms) => terms.iter().any(|c| c.is_aggregating(aggregating_funcs)),
+            Expr::Bool(_) => false,
+            Expr::BinaryOp { left, right, op: _ } => {
+                left.is_aggregating(aggregating_funcs) | right.is_aggregating(aggregating_funcs)
+            }
+            Expr::HasLabel(_, _) => false,
         }
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct MapEntryExpr {
     pub key: Token,
     pub val: Expr,
 }
 
 pub(super) fn plan_expr(pc: &mut PlanningContext, expression: Pair<Rule>) -> Result<Expr> {
+    let mut or_expressions = Vec::new();
     for inner in expression.into_inner() {
         match inner.as_rule() {
-            Rule::string => {
-                let content = inner
-                    .into_inner()
-                    .next()
-                    .expect("Strings should always have an inner value")
-                    .as_str();
-                return Ok(Expr::Lit(Val::String(String::from(content))));
-            }
-            Rule::id => {
-                let tok = pc.tokenize(inner.as_str());
-                return Ok(Expr::Slot(pc.get_or_alloc_slot(tok)));
-            }
-            Rule::prop_lookup => {
-                let mut prop_lookup = inner.into_inner();
-                let prop_lookup_expr = prop_lookup.next().unwrap();
-                let base = match prop_lookup_expr.as_rule() {
-                    Rule::id => {
-                        let tok = pc.tokenize(prop_lookup_expr.as_str());
-                        Expr::Slot(pc.get_or_alloc_slot(tok))
-                    }
-                    _ => unreachable!(),
-                };
-                let mut props = Vec::new();
-                for p_inner in prop_lookup {
-                    if let Rule::id = p_inner.as_rule() {
-                        props.push(pc.tokenize(p_inner.as_str()));
-                    }
+            Rule::and_expr => {
+                let mut and_expressions: Vec<Expr> = Vec::new();
+                for term in inner.into_inner() {
+                    and_expressions.push(plan_term(pc, term)?)
                 }
-                return Ok(Expr::Prop(Box::new(base), props));
-            }
-            Rule::func_call => {
-                let mut func_call = inner.into_inner();
-                let func_name_item = func_call
-                    .next()
-                    .expect("All func_calls must start with an identifier");
-                let name = pc.tokenize(func_name_item.as_str());
-                // Parse args
-                let mut args = Vec::new();
-                for arg in func_call {
-                    args.push(plan_expr(pc, arg)?);
+                if and_expressions.len() == 1 {
+                    or_expressions.push(and_expressions.remove(0))
+                } else {
+                    or_expressions.push(Expr::And(and_expressions))
                 }
-                return Ok(Expr::FuncCall { name, args });
             }
-            Rule::list => {
-                let mut items = Vec::new();
-                let exprs = inner.into_inner();
-                for exp in exprs {
-                    items.push(plan_expr(pc, exp)?);
-                }
-                return Ok(Expr::List(items));
-            }
-            Rule::int => {
-                let v = inner.as_str().parse::<i64>()?;
-                return Ok(Expr::Lit(Val::Int(v)));
-            }
-            Rule::float => {
-                let v = inner.as_str().parse::<f64>()?;
-                return Ok(Expr::Lit(Val::Float(v)));
-            }
-            _ => panic!(String::from(inner.as_str())),
+            _ => panic!("({:?}): {}", inner.as_rule(), inner.as_str()),
         }
     }
-    panic!("Invalid expression from parser.")
+    if or_expressions.len() == 1 {
+        return Ok(or_expressions.remove(0));
+    } else {
+        return Ok(Expr::Or(or_expressions));
+    }
+}
+
+fn plan_term(pc: &mut PlanningContext, term: Pair<Rule>) -> Result<Expr> {
+    match term.as_rule() {
+        Rule::string => {
+            let content = term
+                .into_inner()
+                .next()
+                .expect("Strings should always have an inner value")
+                .as_str();
+            return Ok(Expr::Lit(Val::String(String::from(content))));
+        }
+        Rule::id => {
+            let tok = pc.tokenize(term.as_str());
+            return Ok(Expr::Slot(pc.get_or_alloc_slot(tok)));
+        }
+        Rule::prop_lookup => {
+            let mut prop_lookup = term.into_inner();
+            let prop_lookup_expr = prop_lookup.next().unwrap();
+            let base = match prop_lookup_expr.as_rule() {
+                Rule::id => {
+                    let tok = pc.tokenize(prop_lookup_expr.as_str());
+                    Expr::Slot(pc.get_or_alloc_slot(tok))
+                }
+                _ => unreachable!(),
+            };
+            let mut props = Vec::new();
+            for p_inner in prop_lookup {
+                if let Rule::id = p_inner.as_rule() {
+                    props.push(pc.tokenize(p_inner.as_str()));
+                }
+            }
+            return Ok(Expr::Prop(Box::new(base), props));
+        }
+        Rule::func_call => {
+            let mut func_call = term.into_inner();
+            let func_name_item = func_call
+                .next()
+                .expect("All func_calls must start with an identifier");
+            let name = pc.tokenize(func_name_item.as_str());
+            // Parse args
+            let mut args = Vec::new();
+            for arg in func_call {
+                args.push(plan_expr(pc, arg)?);
+            }
+            return Ok(Expr::FuncCall { name, args });
+        }
+        Rule::list => {
+            let mut items = Vec::new();
+            let exprs = term.into_inner();
+            for exp in exprs {
+                items.push(plan_expr(pc, exp)?);
+            }
+            return Ok(Expr::List(items));
+        }
+        Rule::int => {
+            let v = term.as_str().parse::<i64>()?;
+            return Ok(Expr::Lit(Val::Int(v)));
+        }
+        Rule::float => {
+            let v = term.as_str().parse::<f64>()?;
+            return Ok(Expr::Lit(Val::Float(v)));
+        }
+        Rule::lit_true => return Ok(Expr::Bool(true)),
+        Rule::lit_false => return Ok(Expr::Bool(false)),
+        Rule::binary_op => {
+            let mut parts = term.into_inner();
+            let left = parts.next().expect("binary operators must have a left arg");
+            let op = parts
+                .next()
+                .expect("binary operators must have an operator");
+            let right = parts
+                .next()
+                .expect("binary operators must have a right arg");
+
+            let left_expr = plan_term(pc, left)?;
+            let right_expr = plan_term(pc, right)?;
+            return Ok(Expr::BinaryOp {
+                left: Box::new(left_expr),
+                right: Box::new(right_expr),
+                op: Op::from_str(op.as_str())?,
+            });
+        }
+        Rule::expr => {
+            // this happens when there are parenthetises forcing "full" expressions down here
+            return plan_expr(pc, term);
+        }
+        _ => panic!("({:?}): {}", term.as_rule(), term.as_str()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::{BackendDesc, FuncSignature, FuncType, Token, Tokens};
+    use crate::frontend::{Frontend, LogicalPlan};
+    use crate::Type;
+    use anyhow::Result;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    // Outcome of testing planning; the plan plus other related items to do checks on
+    #[derive(Debug)]
+    struct PlanArtifacts {
+        expr: Expr,
+        slots: HashMap<Token, usize>,
+        tokens: Rc<RefCell<Tokens>>,
+    }
+
+    impl PlanArtifacts {
+        fn slot(&self, k: Token) -> usize {
+            self.slots[&k]
+        }
+
+        fn tokenize(&mut self, content: &str) -> Token {
+            self.tokens.borrow_mut().tokenize(content)
+        }
+    }
+
+    fn plan(q: &str) -> Result<PlanArtifacts> {
+        let tokens = Rc::new(RefCell::new(Tokens::new()));
+        let tok_expr = tokens.borrow_mut().tokenize("expr");
+        let fn_count = tokens.borrow_mut().tokenize("count");
+        let backend_desc = BackendDesc::new(vec![FuncSignature {
+            func_type: FuncType::Aggregating,
+            name: fn_count,
+            returns: Type::Integer,
+            args: vec![(tok_expr, Type::Any)],
+        }]);
+
+        let frontend = Frontend {
+            tokens: Rc::clone(&tokens),
+            backend_desc: BackendDesc::new(vec![]),
+        };
+        let mut pc = PlanningContext {
+            slots: Default::default(),
+            anon_rel_seq: 0,
+            anon_node_seq: 0,
+            tokens: Rc::clone(&tokens),
+            backend_desc: &backend_desc,
+        };
+        let plan = frontend.plan_in_context(&format!("RETURN {}", q), &mut pc);
+
+        if let Ok(LogicalPlan::Return {
+            src: _,
+            projections,
+        }) = plan
+        {
+            return Ok(PlanArtifacts {
+                expr: projections[0].expr.clone(),
+                slots: pc.slots,
+                tokens: Rc::clone(&tokens),
+            });
+        } else {
+            return Err(anyhow!("Expected RETURN plan, got: {:?}", plan?));
+        }
+    }
+
+    #[test]
+    fn plan_boolean_logic() -> Result<()> {
+        assert_eq!(plan("true")?.expr, Expr::Bool(true));
+        assert_eq!(plan("false")?.expr, Expr::Bool(false));
+        assert_eq!(
+            plan("true and false")?.expr,
+            Expr::And(vec![Expr::Bool(true), Expr::Bool(false)])
+        );
+        assert_eq!(
+            plan("true and false and true")?.expr,
+            Expr::And(vec![Expr::Bool(true), Expr::Bool(false), Expr::Bool(true)])
+        );
+        assert_eq!(
+            plan("true or false")?.expr,
+            Expr::Or(vec![Expr::Bool(true), Expr::Bool(false)])
+        );
+        assert_eq!(
+            plan("true or false or true")?.expr,
+            Expr::Or(vec![Expr::Bool(true), Expr::Bool(false), Expr::Bool(true)])
+        );
+        assert_eq!(
+            plan("true and false or true")?.expr,
+            Expr::Or(vec![
+                Expr::And(vec![Expr::Bool(true), Expr::Bool(false)]),
+                Expr::Bool(true)
+            ])
+        );
+        assert_eq!(
+            plan("true or false and true")?.expr,
+            Expr::Or(vec![
+                Expr::Bool(true),
+                Expr::And(vec![Expr::Bool(false), Expr::Bool(true)])
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn plan_binary_operators() -> Result<()> {
+        assert_eq!(
+            plan("true = false")?.expr,
+            Expr::BinaryOp {
+                left: Box::new(Expr::Bool(true)),
+                right: Box::new(Expr::Bool(false)),
+                op: Op::Eq
+            },
+        );
+        assert_eq!(
+            plan("false = ( true = true )")?.expr,
+            Expr::BinaryOp {
+                left: Box::new(Expr::Bool(false)),
+                right: Box::new(Expr::BinaryOp {
+                    left: Box::new(Expr::Bool(true)),
+                    right: Box::new(Expr::Bool(true)),
+                    op: Op::Eq
+                }),
+                op: Op::Eq
+            },
+        );
+        Ok(())
+    }
 }

--- a/src/frontend/expr.rs
+++ b/src/frontend/expr.rs
@@ -18,7 +18,7 @@ impl FromStr for Op {
     fn from_str(s: &str) -> Result<Self> {
         match s {
             "=" => Ok(Op::Eq),
-            _ => Err(anyhow!("Unknown operator: {}", s)),
+            _ => bail!("Unknown operator: {}", s),
         }
     }
 }

--- a/src/frontend/expr.rs
+++ b/src/frontend/expr.rs
@@ -12,8 +12,10 @@ pub enum Op {
     Eq,
 }
 
-impl Op {
-    pub fn from_str(s: &str) -> Result<Op> {
+impl FromStr for Op {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
         match s {
             "=" => Ok(Op::Eq),
             _ => Err(anyhow!("Unknown operator: {}", s)),

--- a/src/frontend/expr.rs
+++ b/src/frontend/expr.rs
@@ -101,11 +101,12 @@ pub(super) fn plan_expr(pc: &mut PlanningContext, expression: Pair<Rule>) -> Res
                 for term in inner.into_inner() {
                     and_expressions.push(plan_term(pc, term)?)
                 }
-                if and_expressions.len() == 1 {
-                    or_expressions.push(and_expressions.remove(0))
+                let and_expr = if and_expressions.len() == 1 {
+                    and_expressions.remove(0)
                 } else {
-                    or_expressions.push(Expr::And(and_expressions))
-                }
+                    Expr::And(and_expressions)
+                };
+                or_expressions.push(and_expr);
             }
             _ => panic!("({:?}): {}", inner.as_rule(), inner.as_str()),
         }

--- a/src/frontend/expr.rs
+++ b/src/frontend/expr.rs
@@ -6,6 +6,7 @@ use crate::frontend::{PlanningContext, Result, Rule};
 use crate::{Slot, Val};
 use pest::iterators::Pair;
 use std::collections::HashSet;
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Op {

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -449,7 +449,7 @@ pub struct PatternGraph {
     //
     // vs the same thing expressed as
     //
-    //   MATCH (a:User), (b:User})
+    //   MATCH (a:User), (b:User)
     //   WHERE a.id = "a" AND b.id = "b"
     //
     // The first will filter `a` down to 1 row before doing the cartesian product over `b`,

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -104,8 +104,7 @@ pub enum LogicalPlan {
     },
     Selection {
         src: Box<Self>,
-        slot: usize,
-        predicate: Predicate,
+        predicate: Expr,
     },
     Create {
         src: Box<Self>,
@@ -435,6 +434,31 @@ pub struct PatternGraph {
     e: HashMap<Token, PatternNode>,
     e_order: Vec<Token>,
     v: Vec<PatternRel>,
+
+    // The following expression must be true for the pattern to match; this can be a
+    // deeply nested combination of Expr::And / Expr::Or. The pattern parser does not guarantee
+    // it is a boolean expression.
+    //
+    // TODO: Currently this contains the entire WHERE clause, forcing evaluation of the WHERE
+    //       predicates once all the expands and scans have been done. This can cause catastrophic
+    //       cases, compared to if predicates where evaluated earlier in the plan.
+    //
+    // Imagine a cartesian join like:
+    //
+    //   MATCH (a:User {id: "a"}), (b:User {id: "b"})
+    //
+    // vs the same thing expressed as
+    //
+    //   MATCH (a:User), (b:User})
+    //   WHERE a.id = "a" AND b.id = "b"
+    //
+    // The first will filter `a` down to 1 row before doing the cartesian product over `b`,
+    // while the latter will first do the cartesian product of *all nodes in the database* and
+    // then filter. The difference is something like 6 orders of magnitude of comparisons made.
+    //
+    // Long story short: We want a way to "lift" predicates out of this filter when we plan MATCH,
+    // so that we filter stuff down as early as possible.
+    predicate: Option<Expr>,
 }
 
 impl PatternGraph {
@@ -464,21 +488,19 @@ fn plan_match(
     fn filter_expand(expand: LogicalPlan, slot: Token, labels: &[Token]) -> LogicalPlan {
         let labels = labels
             .iter()
-            .map(|&label| Predicate::HasLabel(label))
+            .map(|&label| Expr::HasLabel(slot, label))
             .collect::<Vec<_>>();
         if labels.is_empty() {
             expand
         } else if labels.len() == 1 {
             LogicalPlan::Selection {
                 src: Box::new(expand),
-                slot,
                 predicate: labels.into_iter().next().unwrap(),
             }
         } else {
             LogicalPlan::Selection {
                 src: Box::new(expand),
-                slot,
-                predicate: Predicate::And(labels),
+                predicate: Expr::And(labels),
             }
         }
     }
@@ -582,9 +604,20 @@ fn plan_match(
             break;
         }
 
+        // Eg. we currently don't handle circular patterns (requiring JOINs) or patterns
+        // with multiple disjoint subgraphs.
         if !solved_any {
             panic!("Failed to solve pattern: {:?}", pg)
         }
+    }
+
+    // Finally, add the pattern-wide predicate to filter the result of the pattern match
+    // see the note on PatternGraph about issues with this "late filter" approach
+    if let Some(pred) = pg.predicate {
+        return Ok(LogicalPlan::Selection {
+            src: Box::new(plan),
+            predicate: pred,
+        });
     }
 
     Ok(plan)
@@ -622,6 +655,14 @@ fn parse_pattern_graph(pc: &mut PlanningContext, patterns: Pair<Rule>) -> Result
                         _ => unreachable!(),
                     }
                 }
+            }
+            Rule::where_clause => {
+                pg.predicate = Some(plan_expr(
+                    pc,
+                    part.into_inner()
+                        .next()
+                        .expect("where clause must contain a predicate"),
+                )?)
             }
             _ => unreachable!(),
         }
@@ -730,6 +771,7 @@ fn parse_map_expression(
     }
     Ok(out)
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -940,6 +982,7 @@ mod tests {
     #[cfg(test)]
     mod match_ {
         use super::*;
+        use crate::frontend::expr::Op;
 
         #[test]
         fn plan_match_with_anonymous_rel_type() -> Result<()> {
@@ -992,8 +1035,36 @@ mod tests {
                         rel_type: RelType::Defined(tpe_knows),
                         dir: Some(Dir::Out),
                     }),
-                    slot: p.slot(id_o),
-                    predicate: Predicate::HasLabel(lbl_person)
+                    predicate: Expr::HasLabel(p.slot(id_o), lbl_person)
+                }
+            );
+            Ok(())
+        }
+
+        #[test]
+        fn plan_match_with_unhoistable_where() -> Result<()> {
+            let mut p = plan("MATCH (n) WHERE true = opaque()")?;
+            let lbl_person = p.tokenize("Person");
+            let tpe_knows = p.tokenize("KNOWS");
+            let id_n = p.tokenize("n");
+            let id_opaque = p.tokenize("opaque");
+
+            assert_eq!(
+                p.plan,
+                LogicalPlan::Selection {
+                    src: Box::new(LogicalPlan::NodeScan {
+                        src: Box::new(LogicalPlan::Argument),
+                        slot: p.slot(id_n),
+                        labels: None,
+                    }),
+                    predicate: Expr::BinaryOp {
+                        left: Box::new(Expr::Bool(true)),
+                        right: Box::new(Expr::FuncCall {
+                            name: id_opaque,
+                            args: vec![]
+                        }),
+                        op: Op::Eq
+                    }
                 }
             );
             Ok(())


### PR DESCRIPTION
I'm trying to pass the WhereAcceptance.feature, which is why this
includes several disparate things:

- Basic where clause parsing
- Parsing basic binary logic
- Moving the Predicate concepts over to Expr

The planner currently just tacks the predicates in WHERE after it's
solved all the expands, which will have catastrophic performance vs
early evaluation of predicates, but it's a good start. We'll want to
explore "hoisting" predicates up into the plan tree to prune stuff
as early as possible.. but that's likely best done guided by some
benchmarks.